### PR TITLE
Focus element positioning fix for elements inside ng-include

### DIFF
--- a/ng-walkthrough.js
+++ b/ng-walkthrough.js
@@ -383,8 +383,8 @@ angular.module('ng-walkthrough', [])
                     } else {
                         width = focusElement[0].offsetWidth;
                         height = focusElement[0].offsetHeight;
-                        left = focusElement[0].offsetLeft;
-                        top = focusElement[0].offsetTop;
+                        left = focusElement[0].getBoundingClientRect().left;
+                        top = focusElement[0].getBoundingClientRect().top;
                         //var parent = focusElement[0].offsetParent;
 
                         //while (parent) {


### PR DESCRIPTION
When the item to be focused is inside a ng-include directive, the focus windows is always positioned in the top left corner of the screen. 
It is because the offsetLeft and offsetTop attributes of the focusElement[0] element are always 0.
This is fixed by replacing it with getBoundingClientRect(). It returns the rectangle with the correct values.