### PR TITLE
Lock scroll when walkthrough is displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ and use one of the two configurations:
 - `force-caption-location` (optional) - Any walkthrough type. Set caption location at the top of screen or closer to bottom. Acceptable values: "TOP" or "BOTTOM"
 - `tip-color` (optional) - For tip walkthrough. Define the tip textbox background color. Currently supports "BLACK" or "WHITE" values
 - `is-bind-click-event-to-body` (optional) - Any walkthrough type. If 'use-botton' is not set to true, then any this will bind the click events to the body to capture events outside walkthrough, for example: ionic header
+- `is-scroll-disabled` (optional) - Any walkthrough type. If set to true, then class 'walkthrough-lock-scroll' will be added to body when the walkthrough is displayed. This will prevent scrolling during the step
 - `on-walkthrough-show` (optional) - Any walkthrough type. Bind method to be called when walkthrough is displayed
 - `on-walkthrough-hide` (optional) - Any walkthrough type. Bind method to be called when walkthrough is hidden
 

--- a/css/ng-walkthrough.css
+++ b/css/ng-walkthrough.css
@@ -200,3 +200,7 @@
     background-color: #ffffff;
 
 }
+
+.walkthrough-lock-scroll {
+    overflow: hidden;
+}

--- a/ng-walkthrough.js
+++ b/ng-walkthrough.js
@@ -77,6 +77,7 @@ angular.module('ng-walkthrough', [])
                 tipIconLocation: '@',
                 tipColor: '@',
                 isBindClickEventToBody: '=',
+                isScrollDisabled: '=',
                 onWalkthroughShow: '&',
                 onWalkthroughHide: '&'
             },
@@ -181,6 +182,14 @@ angular.module('ng-walkthrough', [])
 
                 var unbindScreenResize = function(){
                     angular.element($window).off('resize', resizeHandler);
+                };
+
+                var disableScroll = function(){
+                    angular.element(document.body).addClass('walkthrough-lock-scroll');
+                };
+
+                var enableScroll = function(){
+                    angular.element(document.body).removeClass('walkthrough-lock-scroll');  
                 };
 
                 var init = function(scope){
@@ -487,6 +496,9 @@ angular.module('ng-walkthrough', [])
                         if (scope.isBindClickEventToBody){
                             bindClickEvents();
                         }
+                        if (scope.isScrollDisabled) {
+                            disableScroll();
+                        }
                         //if (!scope.hasTransclude){//remarked cause did not focus on search field in recipe select
                         try {
                                 if (attrs.focusElementId) {
@@ -505,6 +517,7 @@ angular.module('ng-walkthrough', [])
                         scope.onWalkthroughShow();
                     } else{
                         unbindScreenResize();
+                        enableScroll();
                     }
                 });
 

--- a/test/ng-walkthroughSpec.js
+++ b/test/ng-walkthroughSpec.js
@@ -75,6 +75,40 @@ describe('ng-walkthrough Directive', function() {
         expect($scope.isActive).toBe(false);
     });
 
+    it("Should add class 'walkthrough-lock-scroll' to the body when walkthrough is displayed and flag 'is-scroll-disabled' is set", function(){
+        //Arrange
+        setFixtures('<walkthrough' +
+        ' is-active="true"' + 
+        ' is-scroll-disabled="true">' +
+        '</walkthrough>');
+        $compile($("body"))($scope);
+        $scope.$digest();
+
+        //Assert
+        var $body = angular.element(document.body);
+        expect($body.hasClass('walkthrough-lock-scroll')).toBe(true);
+    });
+
+    it("Should remove class 'walkthrough-lock-scroll' from the body when walkthrough is closed/hidden and flag 'is-scroll-disabled' was set", function(){
+        //Arrange
+        setFixtures('<walkthrough' +
+        ' is-active="true"' + 
+        ' is-scroll-disabled="true">' +
+        '</walkthrough>');
+        $compile($("body"))($scope);
+        $scope.$digest();
+
+        var walkthrough = $('.walkthrough-background');
+
+        //Act
+        walkthrough.click();
+        $scope.$digest();
+
+        //Assert
+        var $body = angular.element(document.body);
+        expect($body.hasClass('walkthrough-lock-scroll')).toBe(false);
+    });
+
     it("Should close the walkthrough upon click anywhere when attribute 'use-button' not set to 'true'", function(){
         //Arrange
         setFixtures('<walkthrough' +


### PR DESCRIPTION
Hi, i've added the functionality to lock the scroll when walkthrough is displayed.
I've done that by adding 'overflow: hidden' to the body. That is implemented by toggling the class 'walkthrough-lock-scroll' that is added to the .css file. I added inline css first, but after consulting with colleagues, I decided to do this through classes. 
I've also added the 'is-scroll-disabled' attribute to the directive which triggers this functionality on or off.
There are some test for the newly added functionality and they pass, hope it's enough.
Finally, the README.md file is also updated.

Hope it will help, and thank you for this great library.