### PR TITLE
Add an option to set focused element by selector

### DIFF
--- a/ng-walkthrough.js
+++ b/ng-walkthrough.js
@@ -63,6 +63,7 @@ angular.module('ng-walkthrough', [])
                 isActive: '=',
                 icon: '@',
                 focusElementId: '@',
+                focusElementSelector: '@',
                 mainCaption: '@',
                 forceCaptionLocation: '@',
                 isRound: '=',
@@ -156,7 +157,7 @@ angular.module('ng-walkthrough', [])
                 };
 
                 var resizeHandler = function(){
-                    scope.setFocusOnElement(attrs.focusElementId);
+                    scope.setFocusOnElement(attrs.focusElementSelector);
                 };
 
                 var unbindClickEvents = function(){
@@ -234,6 +235,11 @@ angular.module('ng-walkthrough', [])
                     },100);
                     scope.walkthroughIcon = getIcon(scope.icon);
                     scope.buttonCaption = BUTTON_CAPTION_DONE;
+
+                    // Change focusElementId in selector if needed
+                    if(!attrs.focusElementSelector && attrs.focusElementId) {
+                        attrs.focusElementSelector = '#' + attrs.focusElementId;
+                    }
                 };
 
                 //Sets the walkthrough focus hole on given params with padding
@@ -403,8 +409,8 @@ angular.module('ng-walkthrough', [])
                 };
 
                 //Attempts to highlight the given element ID and set Icon to it if exists, if not use default - right under text
-                var setElementLocations = function(walkthroughIconWanted, focusElementId, iconPaddingLeft, iconPaddingTop){
-                    var focusElement = (focusElementId)?document.querySelector('#' + focusElementId): null;
+                var setElementLocations = function(walkthroughIconWanted, focusElementSelector, iconPaddingLeft, iconPaddingTop){
+                    var focusElement = (focusElementSelector)?document.querySelector(focusElementSelector): null;
                     var angularElement = (focusElement)?angular.element(focusElement):null;
                     if (angularElement && angularElement.length > 0) {
                         var offsetCoordinates = getOffsetCoordinates(angularElement);
@@ -438,8 +444,8 @@ angular.module('ng-walkthrough', [])
                             setTipIconPadding(iconPaddingLeft, iconPaddingTop);
                         }
                     } else {
-                        if (focusElementId) {
-                            $log.info('Unable to find element requested to be focused: #' + focusElementId);
+                        if (focusElementSelector) {
+                            $log.info('Unable to find element requested to be focused: ' + focusElementSelector);
                         } else{
                             //if tip mode with icon that we want to set padding to, set it
                             if (scope.walkthroughType== "tip" &&
@@ -451,8 +457,8 @@ angular.module('ng-walkthrough', [])
                     }
                 };
 
-                scope.setFocusOnElement = function(focusElementId){
-                    setElementLocations(scope.icon, focusElementId, scope.iconPaddingLeft, scope.iconPaddingTop);
+                scope.setFocusOnElement = function(focusElementSelector){
+                    setElementLocations(scope.icon, focusElementSelector, scope.iconPaddingLeft, scope.iconPaddingTop);
                 };
 
                 var holeElements = element[0].querySelectorAll(DOM_WALKTHROUGH_HOLE_CLASS);
@@ -489,16 +495,16 @@ angular.module('ng-walkthrough', [])
                         }
                         //if (!scope.hasTransclude){//remarked cause did not focus on search field in recipe select
                         try {
-                                if (attrs.focusElementId) {
-                                    scope.setFocusOnElement(attrs.focusElementId);
+                                if (attrs.focusElementSelector) {
+                                    scope.setFocusOnElement(attrs.focusElementSelector);
                                 }
                             } catch(e){
-                                $log.warn('failed to focus on element prior to timeout: ' + attrs.focusElementId);
+                                $log.warn('failed to focus on element prior to timeout: ' + attrs.focusElementSelector);
                             }
                             //Must timeout to make sure we have final correct coordinates after screen totally load
-                            if (attrs.focusElementId) {
+                            if (attrs.focusElementSelector) {
                                 $timeout(function () {
-                                    scope.setFocusOnElement(attrs.focusElementId);
+                                    scope.setFocusOnElement(attrs.focusElementSelector);
                                 }, 300);
                             }
                         //}

--- a/test/ng-walkthroughSpec.js
+++ b/test/ng-walkthroughSpec.js
@@ -195,6 +195,40 @@ describe('ng-walkthrough Directive', function() {
         expect(walkthroughFocusedHole[0].offsetWidth).toBe(walkthroughFocusedItem[0].offsetWidth + 2* padding);
     });
 
+    it("Should create highlight/focus on element with the given DOM selector set in attribute 'focus-element-selector'", function(){
+        //Arrange
+        var marginLeft = 50;
+        var width = 150;
+        var marginTop = 50;
+        var height = 150;
+        var padding = 5;
+
+        var walkthroughHole = ".walkthrough-hole";
+        var mockedFocusItemClass = "mockedFocusItemClass";
+        var mockedFocusItemSelector = "div." + mockedFocusItemClass;
+        setFixtures('<walkthrough' +
+        ' is-active="isActive"' +
+        ' walkthrough-type="transparency"' +
+        ' focus-element-selector="' + mockedFocusItemSelector + '">' +
+        '</walkthrough>');
+
+        jasmine.getFixtures().appendSet('<div class="' + mockedFocusItemClass  + '" style="margin-left:' + marginLeft + 'px;width:' + width + 'px;margin-top:' + marginTop + 'px;height:' + height + 'px;display: inline-block;"></div>');
+
+        $compile($("body"))($scope);
+
+        //Act
+        $scope.isActive = true;
+        $timeout.flush();
+        var walkthroughFocusedItem = angular.element($(mockedFocusItemSelector));
+        var walkthroughFocusedHole = angular.element($(walkthroughHole));
+
+        //Assert
+        expect(walkthroughFocusedHole[0].offsetHeight).toBe(walkthroughFocusedItem[0].offsetHeight + 2* padding);
+        expect(walkthroughFocusedHole[0].offsetLeft).toBe(walkthroughFocusedItem[0].offsetLeft - padding);
+        expect(walkthroughFocusedHole[0].offsetTop).toBe(walkthroughFocusedItem[0].offsetTop - padding);
+        expect(walkthroughFocusedHole[0].offsetWidth).toBe(walkthroughFocusedItem[0].offsetWidth + 2* padding);
+    });
+    
     it("Should add glow around highlight/focus element when attribute 'has-glow' set to 'true'", function(){
         //Arrange
         var marginLeft = 50;


### PR DESCRIPTION
Hello, I am trying your lib and I found myself having hard time to add ids in ionic directives.
So I made a quick evolution to be able to find the element with a selector (`'a.ion-home'` for example).

I kept the original attribute to be compatible with backward versions.

You can merge it if you like.

Thank you for this lib,

Regards