### PR TITLE
Add allow-html-caption support

### DIFF
--- a/ng-walkthrough.js
+++ b/ng-walkthrough.js
@@ -27,7 +27,9 @@ angular.module('ng-walkthrough', [])
                 '<div class="'+ DOM_TRANSCLUDE + '"></div>',
                 '<div class="walkthrough-non-transclude-template" ng-show="!hasTransclude">',
                 '<div class="walkthrough-text-container" ng-class="{\'walkthrough-top\': (!forceCaptionLocation || forceCaptionLocation==\'TOP\'), \'walkthrough-bottom\': forceCaptionLocation==\'BOTTOM\'}">',
-                '<pre class="walkthrough-element walkthrough-text" ng-bind="mainCaption">',
+                '<pre class="walkthrough-element walkthrough-text" ng-bind="mainCaption" ng-if="allowHtmlCaption != true">',
+                '</pre>',
+                '<pre class="walkthrough-element walkthrough-text" ng-bind-html="mainCaption" ng-if="allowHtmlCaption">',
                 '</pre>',
                 '</div>',
                 '<img class="walkthrough-element walkthrough-icon" ng-show="icon && icon!=\'arrow\'" ng-src="{{walkthroughIcon}}">',
@@ -45,7 +47,9 @@ angular.module('ng-walkthrough', [])
                 '<img class="walkthrough-tip-button-image-text-box" ng-src="{{closeIcon}}" alt="x">',
                 '</button>',
                 '<div class="walkthrough-element walkthrough-tip-text-box" ng-class="{\'walkthrough-tip-text-box-color-black\': tipColor==\'BLACK\', \'walkthrough-tip-text-box-color-white\': tipColor==\'WHITE\'}">',
-                '<pre ng-bind="mainCaption">',
+                '<pre ng-bind="mainCaption" ng-if="allowHtmlCaption != true">',
+                '</pre>',
+                '<pre ng-bind-html="mainCaption" ng-if="allowHtmlCaption">',
                 '</pre>',
                 '<div class="'+ DOM_TRANSCLUDE + '"></div>',
                 '</div>',
@@ -78,7 +82,8 @@ angular.module('ng-walkthrough', [])
                     tipIconLocation: '@?',
                     tipColor: '@?',
                     onWalkthroughShow: '&',
-                    onWalkthroughHide: '&'
+                    onWalkthroughHide: '&',
+                    allowHtmlCaption: '=?'
                 },
                 link: function (scope, element, attrs, ctrl, $transclude) {
                     var getIcon = function(icon){

--- a/test/ng-walkthroughSpec.js
+++ b/test/ng-walkthroughSpec.js
@@ -821,4 +821,29 @@ describe('ng-walkthrough Directive', function() {
         $scope.isMoved = true;
         $scope.$digest();
     });
+
+    it("should allow HTML in mainCaption when allowHtmlCaption is true", function(done){
+        //Arrange
+        var expectedText = "mocked walk-through text";
+        setFixtures('<walkthrough' +
+        ' is-active="isActive"' +
+        ' walkthrough-type="transparency"' +
+        ' main-caption="{{caption}}"' +
+        ' allow-html-caption="true">' +
+        '</walkthrough>');
+        $compile($("body"))($scope);
+
+        //Act
+        $scope.isActive = true;
+        $scope.caption = "<h2>expectedText</h2>";
+        $scope.$digest();
+        var walkthroughText = $('.walkthrough-text');
+
+        //Assert
+        window.setTimeout(function () {
+            expect(walkthroughText[0].querySelector("h2")).not.toBe(null);
+            expect(walkthroughText[0].querySelector("h2").textContent).toBe(expectedText);
+            done();
+        }, 100);
+    })
 });

--- a/test/ng-walkthroughSpec.js
+++ b/test/ng-walkthroughSpec.js
@@ -4,9 +4,11 @@ describe('ng-walkthrough Directive', function() {
     var $scope;
     var $httpBackend;
     var $timeout;
+    var $sce;
     var ngWalkthroughTapIcons;
 
     beforeEach(module('ng-walkthrough'));
+    beforeEach(module('ngSanitize'));
 
     //For the new Jasmine 2.0
     beforeEach(function(done) {
@@ -15,7 +17,7 @@ describe('ng-walkthrough Directive', function() {
 
     // Store references to $rootScope and $compile
     // so they are available to all tests in this describe block
-    beforeEach(inject(function(_$compile_, _$rootScope_, _$timeout_, _$httpBackend_, _ngWalkthroughTapIcons_){
+    beforeEach(inject(function(_$compile_, _$rootScope_, _$timeout_, _$httpBackend_, _ngWalkthroughTapIcons_, _$sce_){
         jasmine.getStyleFixtures().fixturesPath = 'base';
         loadStyleFixtures('css/ng-walkthrough.css');
 
@@ -29,6 +31,7 @@ describe('ng-walkthrough Directive', function() {
         $rootScope = _$rootScope_;
         $scope = $rootScope.$new();
         $timeout = _$timeout_;
+        $sce = _$sce_;
         ngWalkthroughTapIcons = _ngWalkthroughTapIcons_;
     }));
 
@@ -835,7 +838,7 @@ describe('ng-walkthrough Directive', function() {
 
         //Act
         $scope.isActive = true;
-        $scope.caption = "<h2>expectedText</h2>";
+        $scope.caption = $sce.trustAsHtml("<h2>expectedText</h2>");
         $scope.$digest();
         var walkthroughText = $('.walkthrough-text');
 

--- a/test/ng-walkthroughSpec.js
+++ b/test/ng-walkthroughSpec.js
@@ -838,7 +838,7 @@ describe('ng-walkthrough Directive', function() {
 
         //Act
         $scope.isActive = true;
-        $scope.caption = $sce.trustAsHtml("<h2>expectedText</h2>");
+        $scope.caption = $sce.trustAsHtml("<h2>" + expectedText + "</h2>");
         $scope.$digest();
         var walkthroughText = $('.walkthrough-text');
 


### PR DESCRIPTION
In my app, I want to allow custom HTML text formatting stuff like `<br/>` or `<small>....</small>`s within the text, but I don't want to have to duplicate the whole structure and logic of the plain-old-caption mode myself.

It'd be nice to have an off-by-default flag that allows me to use ng-bind-html instead of just ng-bind so that my captions can contain HTML formatting.

This PR implements that flag.
